### PR TITLE
#5: Implement RetConDiscoveryLevel.RequireSignedAssembliesOnly

### DIFF
--- a/ClientAPI/Program.cs
+++ b/ClientAPI/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // Add RetCon configuration logic
-builder.AddRetConTargetServices(RetConDiscoveryLevel.RequireSignedAssemblies);
+builder.AddRetConTargetServices(RetConDiscoveryLevel.AllowUnsignedAssemblies);
 
 var app = builder.Build();
 

--- a/GraniteStateUsersGroups.RetCons.Web/ConfigurationExtensions.cs
+++ b/GraniteStateUsersGroups.RetCons.Web/ConfigurationExtensions.cs
@@ -8,10 +8,10 @@ public static class ConfigurationExtensions
 {
        
 
-    public static WebApplicationBuilder AddRetConTargetServices(this WebApplicationBuilder builder, RetConDiscoveryLevel level)
+    public static WebApplicationBuilder AddRetConTargetServices(this WebApplicationBuilder builder, AssemblyDiscoveryStrategy strategy)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        RetConComposer.RegisterRetConServices(builder, level);
+        RetConComposer.RegisterRetConServices(builder, strategy);
         ConfigRetConTargetServices(builder);
         return builder;
     }

--- a/GraniteStateUsersGroups.RetCons/RetConComposer.cs
+++ b/GraniteStateUsersGroups.RetCons/RetConComposer.cs
@@ -104,54 +104,7 @@ public static class RetConComposer
         }
     }
 
-    private static readonly Action<ILogger, string, string?, string?, ServiceLifetime, Exception?> LogRetConAdded =
-        LoggerMessage.Define<string, string?, string?, ServiceLifetime>(
-            LogLevel.Information,
-            new EventId(0, nameof(RegisterRetCon)),
-            "RetCon: {RetconName} added ({ImplementationName}) as implementation for interface '{InterfaceName}' with lifetime '{ServiceLifetime}')."
-        );
 
-    private static readonly Action<ILogger, Exception?> LogRetConStarted =
-        LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(1, nameof(InitializeRetCons)),
-            "RetCon: InitializeRetCons started."
-        );
-
-    private static readonly Action<ILogger, Exception?> LogRetConFailed =
-        LoggerMessage.Define(
-            LogLevel.Error,
-            new EventId(2, nameof(InitializeRetCons)),
-            "RetCon: InitializeRetCons failed with exceptions (see details)."
-        );
-
-    private static readonly Action<ILogger, Exception?> LogRetConComplete =
-        LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(3, nameof(InitializeRetCons)),
-            "RetCon: InitializeRetCons complete."
-        );
-
-    private static readonly Action<ILogger, string, string, Exception?> LogScanningAssemblies =
-        LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(4, nameof(GetAssembliesThatReferenceType)),
-            "RetCon: Scanning for assemblies matching \"{FullName}\\{FileSearchPattern}\"."
-        );
-
-    private static readonly Action<ILogger, string, string, Exception?> LogExaminingLibraries =
-        LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(5, nameof(GetAssembliesThatReferenceType)),
-            "RetCon: Examining matched libraries for assemblies with references to {FullName}: {LibNames}."
-        );
-
-    private static readonly Action<ILogger, string, string, Exception?> LogSkippingAssembly =
-        LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(6, nameof(GetAssembliesThatReferenceType)),
-            "RetCon: '{AssemblyName}' does not appear to be a compatible assembly. Skipping. {Message}"
-        );
 
     private static IEnumerable<Assembly> GetAssembliesThatReferenceType(Type referencedType, ILogger logger, string searchFolder, string fileSearchPattern, RetConDiscoveryLevel discoveryLevel)
     {
@@ -200,4 +153,53 @@ public static class RetConComposer
 
         return false;
     }
+
+    private static readonly Action<ILogger, string, string?, string?, ServiceLifetime, Exception?> LogRetConAdded =
+    LoggerMessage.Define<string, string?, string?, ServiceLifetime>(
+        LogLevel.Information,
+        new EventId(0, nameof(RegisterRetCon)),
+        "RetCon: {RetconName} added ({ImplementationName}) as implementation for interface '{InterfaceName}' with lifetime '{ServiceLifetime}')."
+    );
+
+    private static readonly Action<ILogger, Exception?> LogRetConStarted =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(1, nameof(InitializeRetCons)),
+            "RetCon: InitializeRetCons started."
+        );
+
+    private static readonly Action<ILogger, Exception?> LogRetConFailed =
+        LoggerMessage.Define(
+            LogLevel.Error,
+            new EventId(2, nameof(InitializeRetCons)),
+            "RetCon: InitializeRetCons failed with exceptions (see details)."
+        );
+
+    private static readonly Action<ILogger, Exception?> LogRetConComplete =
+        LoggerMessage.Define(
+            LogLevel.Information,
+            new EventId(3, nameof(InitializeRetCons)),
+            "RetCon: InitializeRetCons complete."
+        );
+
+    private static readonly Action<ILogger, string, string, Exception?> LogScanningAssemblies =
+        LoggerMessage.Define<string, string>(
+            LogLevel.Information,
+            new EventId(4, nameof(GetAssembliesThatReferenceType)),
+            "RetCon: Scanning for assemblies matching \"{FullName}\\{FileSearchPattern}\"."
+        );
+
+    private static readonly Action<ILogger, string, string, Exception?> LogExaminingLibraries =
+        LoggerMessage.Define<string, string>(
+            LogLevel.Information,
+            new EventId(5, nameof(GetAssembliesThatReferenceType)),
+            "RetCon: Examining matched libraries for assemblies with references to {FullName}: {LibNames}."
+        );
+
+    private static readonly Action<ILogger, string, string, Exception?> LogSkippingAssembly =
+        LoggerMessage.Define<string, string>(
+            LogLevel.Information,
+            new EventId(6, nameof(GetAssembliesThatReferenceType)),
+            "RetCon: '{AssemblyName}' does not appear to be a compatible assembly. Skipping. {Message}"
+        );
 }

--- a/GraniteStateUsersGroups.RetCons/RetConComposer.cs
+++ b/GraniteStateUsersGroups.RetCons/RetConComposer.cs
@@ -1,11 +1,6 @@
-﻿
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System.Reflection;
-using System.Runtime.Loader;
-using System.Security;
 
 namespace GraniteStateUsersGroups.RetCons;
 
@@ -17,12 +12,12 @@ public static class RetConComposer
 
     public const string RetConServiceKey = "RetConServiceKey";
 
-    public static IHostApplicationBuilder RegisterRetConServices(this IHostApplicationBuilder builder, RetConDiscoveryLevel discoveryLevel)
+    public static IHostApplicationBuilder RegisterRetConServices(this IHostApplicationBuilder builder, AssemblyDiscoveryStrategy discoveryStrategy)
     {
         ArgumentNullException.ThrowIfNull(builder);
         RetCon.Context.Builder = builder;
         RegisterBaseServices();
-        InitializeRetCons(discoveryLevel);
+        InitializeRetCons(discoveryStrategy);
         return builder;
     }
 
@@ -38,13 +33,13 @@ public static class RetConComposer
             .CreateLogger(typeof(RetCon.RetConBaseAttribute));
     }
 
-    private static void InitializeRetCons(RetConDiscoveryLevel discoveryLevel)
+    private static void InitializeRetCons(AssemblyDiscoveryStrategy discoveryStrategy)
     {
         try
         {
             var builder = RetCon.Context.Builder;
             LogRetConStarted(RetCon.Context.Logger!, null);
-            DiscoverRetCons(discoveryLevel);
+            DiscoverRetCons(discoveryStrategy);
             RegisterSelectedRetCons();
         }
         catch (Exception ex)
@@ -62,17 +57,9 @@ public static class RetConComposer
         }
     }
 
-    private static void DiscoverRetCons(RetConDiscoveryLevel discoveryLevel)
+    private static void DiscoverRetCons(AssemblyDiscoveryStrategy discoveryStrategy)
     {
-        var configuration = RetCon.Context.ConfigurationBuilder!.Build();
-        var logger = RetCon.Context.Logger;
-        var fileSearchPattern = configuration!["ImplementationAssemblySearch"] ?? "*.dll";
-        var rootAssembly = Assembly.GetEntryAssembly() ?? throw new InvalidOperationException("Entry assembly cannot be null.");
-        var exeFolder = new DirectoryInfo(rootAssembly.Location)?.Parent ?? throw new InvalidOperationException("Parent directory cannot be null.");
-
-        var fileSearchFolder = configuration["ImplementationAssemblyFolder"] ?? exeFolder.FullName;
-
-        var qualifiedAssemblies = GetAssembliesThatReferenceType(typeof(RetCon.RetConBaseAttribute), logger!, fileSearchFolder, fileSearchPattern, discoveryLevel);
+        var qualifiedAssemblies = discoveryStrategy();
         qualifiedAssemblies.GetRetConImplementations(AccumulateImplementations);
     }
 
@@ -106,54 +93,6 @@ public static class RetConComposer
 
 
 
-    private static IEnumerable<Assembly> GetAssembliesThatReferenceType(Type referencedType, ILogger logger, string searchFolder, string fileSearchPattern, RetConDiscoveryLevel discoveryLevel)
-    {
-        var keyAssembly = Assembly.GetAssembly(referencedType) ?? throw new ArgumentOutOfRangeException(nameof(referencedType), "referencedType must be ");
-        var searchFolderDir = new DirectoryInfo(searchFolder) ?? throw new ArgumentOutOfRangeException(nameof(searchFolder), "searchFolder must be a valid directory path.");
-        LogScanningAssemblies(logger, searchFolder, fileSearchPattern, null);
-
-        var localLibFileNames = fileSearchPattern.Split(";")
-            .SelectMany(pattern => searchFolderDir.GetFiles(pattern))
-            .Distinct()
-            .Where(name => !name.Name.StartsWith("system.", StringComparison.InvariantCultureIgnoreCase));
-
-        LogExaminingLibraries(logger, keyAssembly.FullName!, string.Join(";", localLibFileNames.Select(lib => lib.Name)), null);
-        var allAssembliesInBinFolder = localLibFileNames
-            .Select(anAssembly =>
-            {
-                Assembly? result = null;
-                try
-                {
-                    result = AssemblyLoadContext.Default.LoadFromAssemblyPath(anAssembly.FullName);
-                    if (discoveryLevel == RetConDiscoveryLevel.RequireSignedAssemblies && !IsAssemblySigned(result))
-                    {
-                        throw new SecurityException("Assembly Not Signed or Invalid Signature.");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    LogSkippingAssembly(logger, anAssembly.FullName, ex.Message, null);
-                }
-                return result;
-            });
-        var qualifiedAssemblies = allAssembliesInBinFolder
-            .Where(a => a?.GetReferencedAssemblies().Any(a => a.FullName == keyAssembly.FullName) ?? false)
-            .Cast<Assembly>().Union([typeof(RetCon.RetConBaseAttribute).Assembly]).Distinct();
-        return qualifiedAssemblies;
-    }
-
-    private static bool IsAssemblySigned(Assembly assembly)
-    {
-        var publicKey = assembly.GetName().GetPublicKey();
-        var publicKeyToken = assembly.GetName().GetPublicKeyToken();
-        if (publicKey?.Length > 0 && publicKeyToken?.Length > 0)
-        {
-            return true;
-        }
-
-        return false;
-    }
-
     private static readonly Action<ILogger, string, string?, string?, ServiceLifetime, Exception?> LogRetConAdded =
     LoggerMessage.Define<string, string?, string?, ServiceLifetime>(
         LogLevel.Information,
@@ -182,24 +121,5 @@ public static class RetConComposer
             "RetCon: InitializeRetCons complete."
         );
 
-    private static readonly Action<ILogger, string, string, Exception?> LogScanningAssemblies =
-        LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(4, nameof(GetAssembliesThatReferenceType)),
-            "RetCon: Scanning for assemblies matching \"{FullName}\\{FileSearchPattern}\"."
-        );
 
-    private static readonly Action<ILogger, string, string, Exception?> LogExaminingLibraries =
-        LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(5, nameof(GetAssembliesThatReferenceType)),
-            "RetCon: Examining matched libraries for assemblies with references to {FullName}: {LibNames}."
-        );
-
-    private static readonly Action<ILogger, string, string, Exception?> LogSkippingAssembly =
-        LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(6, nameof(GetAssembliesThatReferenceType)),
-            "RetCon: '{AssemblyName}' does not appear to be a compatible assembly. Skipping. {Message}"
-        );
 }

--- a/GraniteStateUsersGroups.RetCons/RetConDiscoveryLevel.cs
+++ b/GraniteStateUsersGroups.RetCons/RetConDiscoveryLevel.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace GraniteStateUsersGroups.RetCons;
+
+public delegate Assembly[] AssemblyDiscoveryStrategy();
+
+public static class RetConDiscoveryLevel
+{
+    private static string qualifyingAssembly { get; } = typeof(RetCon).Assembly.FullName!;
+
+
+    public static readonly AssemblyDiscoveryStrategy AllowUnsignedAssemblies = () =>
+    {
+        var configuration = RetCon.Context.ConfigurationBuilder!.Build();
+        var fileSearchPath = configuration["ImplementationAssemblySearch"] ?? "*.dll";
+        var localLibFileNames = Directory.GetFiles(AppContext.BaseDirectory, fileSearchPath)
+            .ToList();
+
+        var logger = RetCon.Context.Logger!;
+
+        LogScanningForAssemblies!(logger, AppContext.BaseDirectory, fileSearchPath, null);
+        LogExaminingMatchedLibraries!(logger, qualifyingAssembly, string.Join(";", localLibFileNames.Select(lib => lib)), null);
+
+        var allAssembliesInBinFolder = localLibFileNames
+        .Select(AssembliesOnly(logger));
+        var retConAssemblyName = typeof(RetCon).Assembly.GetName().FullName;
+        var qualifiedAssemblies = allAssembliesInBinFolder
+            .Where(a => a?.GetReferencedAssemblies().Any(r => r.FullName == retConAssemblyName) == true)
+            .Distinct()
+            .ToArray();
+        return qualifiedAssemblies.ToArray()!;
+
+    };
+
+    private static Func<string, Assembly?> AssembliesOnly(ILogger logger)
+    {
+        return anAssembly =>
+        {
+            Assembly? result = null;
+            try
+            {
+                result = AssemblyLoadContext.Default.LoadFromAssemblyPath(anAssembly);
+            }
+            catch (Exception ex)
+            {
+                if (logger != null)
+                {
+                    LogSkippingIncompatibleAssembly!(logger!, anAssembly, ex.Message, null);
+                }
+            }
+            return result;
+        };
+    }
+
+    public static readonly AssemblyDiscoveryStrategy RequireSignedAssemblies = () => {
+        var allAssemblies = AllowUnsignedAssemblies();
+        var signedAssemblies = allAssemblies
+            .Where(a => (a.GetName().GetPublicKey()?.Length ?? 0) > 0)
+            .ToArray();
+        return signedAssemblies;
+    };
+
+    private static readonly Action<ILogger, string, string, Exception?> LogScanningForAssemblies 
+        = LoggerMessage.Define<string, string>(
+        LogLevel.Information,
+        new EventId(0, nameof(LogScanningForAssemblies)),
+        "RetCon: Scanning for assemblies in {Path} with pattern {Pattern}."
+    );
+
+    private static readonly Action<ILogger, string, string, Exception?> LogExaminingMatchedLibraries 
+        = LoggerMessage.Define<string, string>(
+        LogLevel.Information,
+        new EventId(1, nameof(LogExaminingMatchedLibraries)),
+        "RetCon: Examining matched libraries for assemblies with references to {FullName}: {LibNames}."
+    );
+
+    private static readonly Action<ILogger, string, string, Exception?> LogSkippingIncompatibleAssembly 
+        = LoggerMessage.Define<string, string>(
+        LogLevel.Warning,
+        new EventId(2, nameof(LogSkippingIncompatibleAssembly)),
+        "RetCon: '{AssemblyName}' does not appear to be a compatible assembly. Skipping. {Message}"
+    );
+
+
+}

--- a/GraniteStateUsersGroups.RetCons/RetConScanLevel.cs
+++ b/GraniteStateUsersGroups.RetCons/RetConScanLevel.cs
@@ -1,7 +1,0 @@
-﻿namespace GraniteStateUsersGroups.RetCons;
-
-public enum RetConDiscoveryLevel
-{
-    RequireSignedAssemblies,
-    AllowUnsignedAssemblies
-}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The RetCons library is a lightweight but powerful .NET utility designed to simpl
 - **Configuration-Driven Implementations**: Dynamically register services based on configuration settings.
 - **Extensible and Modular**: Easily extend the library to meet your specific needs.
 - **Kubernetes-Friendly Composition**: Complement Kubernetes-based platforms with "module-lithic" services as an alternative to microservices.
+- **Extensible Discovery Strategy Mechanism**: Customize the discovery and registration process using strategies.
 
 ## Why RetCon?
 
@@ -30,7 +31,6 @@ Add the RetCon library to your project by referencing the `GraniteStateUsersGrou
 ### Usage
 
 1. **Define Your Interface and Implementation**:
-
    ```csharp
    public interface IExampleService
    {
@@ -43,7 +43,6 @@ Add the RetCon library to your project by referencing the `GraniteStateUsersGrou
        public void Execute() => Console.WriteLine("Default Implementation");
    }
    ```
-
 2. **Register and Initialize Services**:
 
    Use the following methods in your `Program.cs` file to discover and register service implementations and initialize activated services:
@@ -61,8 +60,7 @@ Add the RetCon library to your project by referencing the `GraniteStateUsersGrou
 
    app.Run();
    ```
-
-   - `AddRetConTargetServices`: Discovers and registers service implementations dynamically based on the RetCon attributes.
+- `AddRetConTargetServices`: Discovers and registers service implementations dynamically based on the RetCon attributes.
    - `UseRetConTargetServices`: Initializes the activated services after the application has been built.
 
 3. **Use `ISelfConfig` and `ISelfConfigAfterBuild` Interfaces**:
@@ -71,6 +69,7 @@ Add the RetCon library to your project by referencing the `GraniteStateUsersGrou
 
   
    - **Configuration Subclass Contained Within the Service Class**:
+These examples illustrate how to use `ISelfConfig` and `ISelfConfigAfterBuild` to inject custom logic during the application’s configuration and post-build phases.
 
      ```csharp
      [RetCon.Default(typeof(IMyServiceInterface)]
@@ -93,6 +92,7 @@ Add the RetCon library to your project by referencing the `GraniteStateUsersGrou
 
    These examples illustrate how to use `ISelfConfig` and `ISelfConfigAfterBuild` to inject custom logic during the application’s configuration and post-build phases.
 
+RetCon provides an extensible strategy mechanism to customize the discovery and registration process. You can implement your own strategy by implementing delegate `RetConDiscoveryStrategy` and registering it:
 ### Example Projects
 
 This repository includes sample projects demonstrating how to use RetCon attributes in real-world scenarios. Explore the samples to see how RetCon can simplify your dependency injection setup.


### PR DESCRIPTION
Replaced the enum with a strategy delegate, which also makes it customizable.