### PR TITLE
Fix OpenApiVersion

### DIFF
--- a/Examples/Web/ClientAPI/Program.cs
+++ b/Examples/Web/ClientAPI/Program.cs
@@ -19,7 +19,7 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 //if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
+    app.UseSwagger(options => { options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0; });
     app.UseSwaggerUI();
 }
 


### PR DESCRIPTION
Openapi now requires setting the version, so the example app was broken.  This fixes it.